### PR TITLE
Support Mac shortcuts and clipboard

### DIFF
--- a/RawFontAware.js
+++ b/RawFontAware.js
@@ -186,15 +186,15 @@ function onKeyDown(e) {
 	}
 }
 
-function updateTextarea(element) {
+function updateTextarea(element, insertValue) {
 	var start = element.selectionStart;
 	var end = element.selectionEnd;
 	var s = element.value;
 	var sBefore = s.substring(0, end);
 	var sAfter = s.substring(end);
-	var sBeforeNormalized = raw2sym(sym2raw(sBefore));
+	var sBeforeNormalized = raw2sym(sym2raw(sBefore + (insertValue || "")));
 	var offset = sBeforeNormalized.length - sBefore.length;
-	element.value = raw2sym(sym2raw(s));
+	element.value = sBeforeNormalized + raw2sym(sym2raw(sAfter));
 	element.selectionEnd = end + offset;
 	if (start == end) {
 		element.selectionStart = end + offset;
@@ -215,4 +215,14 @@ function mountTextarea(element) {
 
 function getValue(element) {
 	return sym2raw(element.value);
+}
+
+function setValue(element, value) {
+	element.value = raw2sym(value);
+	return getValue(element);
+}
+
+function insertAtCaret(element, value) {
+	updateTextarea(element, value);
+	return getValue(element);
 }

--- a/RawFontAware.js
+++ b/RawFontAware.js
@@ -114,7 +114,7 @@ function adjustSelection(element, moveRight) {
 	var charBefore = s.substr(end-1, 1);
 	var charAfter = s.substr(end, 1);
 	var insideLF = charBefore == SYMBOL_LF && charAfter == LF;
-	var selection = end < start ? s.substring(end, start) : s.substring(start, end);
+	var selection = s.substring(start, end);
 
 	// if newline is selected via mouse double-click,
 	// expand the selection to include the preceding LF symbol

--- a/RawFontAware.js
+++ b/RawFontAware.js
@@ -10,6 +10,7 @@ var KEY_UP        = 38;
 var KEY_RIGHT     = 39;
 var KEY_DOWN      = 40;
 var KEY_DELETE    = 46;
+var KEY_LETTER_F  = 70;
 
 var LF = "\n";
 var SYMBOL_LF = "\u240A";
@@ -105,7 +106,7 @@ function raw2sym(s) {
 	return s;
 }
 
-function adjustSelection(element, keyCode) {
+function adjustSelection(element, moveRight) {
 	var start = element.selectionStart;
 	var end = element.selectionEnd;
 	var s = element.value;
@@ -126,7 +127,7 @@ function adjustSelection(element, keyCode) {
 	// move it one symbol to the right or to the left
 	// depending on the keyCode
 	if (insideLF) {
-		element.selectionEnd = keyCode == KEY_RIGHT ? end + 1 : end - 1;
+		element.selectionEnd = moveRight ? end + 1 : end - 1;
 		if (start == end) {
 			element.selectionStart = element.selectionEnd;
 		}
@@ -149,15 +150,16 @@ function onMouseUp(e) {
 }
 
 function onKeyDown(e) {
-	// if we are about to move caret, request selection
-	// adjustment after the keydown event is processed
-	if (e.keyCode >= KEY_PAGEUP && e.keyCode <= KEY_DOWN) {
-		var self = this;
-		setTimeout(function() {
-			adjustSelection(self, e.keyCode);
-		}, 0);
-		return;
-	}
+	// request selection adjustment
+	// after the keydown event is processed
+
+	// on Mac, there's a Control+F alternative to pressing right arrow
+	var moveRight = e.keyCode == KEY_RIGHT || (e.ctrlKey && e.keyCode == KEY_LETTER_F);
+
+	var self = this;
+	setTimeout(function() {
+		adjustSelection(self, moveRight);
+	}, 0);
 
 	var start = this.selectionStart;
 	var end = this.selectionEnd;

--- a/RawFontAware.js
+++ b/RawFontAware.js
@@ -186,6 +186,28 @@ function onKeyDown(e) {
 	}
 }
 
+function onCopyOrCut(e) {
+	// on cut or copy, we want to have raw text in clipboard
+	// (without special characters) for interoperability
+	// with other applications and parts of the UI
+
+	// cancel the default event
+	e.preventDefault();
+
+	// get selection, convert it and put into clipboard
+	var start = this.selectionStart;
+	var end = this.selectionEnd;
+	var selection = sym2raw(this.value.substring(start, end))
+
+	// IE11 uses `Text` instead of `text/plain` content type
+	// and global window.clipboardData instead of e.clipboardData
+	if (e.clipboardData) {
+		e.clipboardData.setData('text/plain', selection);
+	} else {
+		window.clipboardData.setData('Text', selection);
+	}
+}
+
 function updateTextarea(element, insertValue) {
 	var start = element.selectionStart;
 	var end = element.selectionEnd;
@@ -211,6 +233,8 @@ function mountTextarea(element) {
 	element.addEventListener('keydown', onKeyDown);
 	element.addEventListener('mousedown', onMouseDown);
 	element.addEventListener('mouseup', onMouseUp);
+	element.addEventListener('copy', onCopyOrCut);
+	element.addEventListener('cut', onCopyOrCut);
 }
 
 function getValue(element) {

--- a/RawFontAware.js
+++ b/RawFontAware.js
@@ -203,6 +203,14 @@ function onInput(e) {
 	updateTextarea(this);
 }
 
+function mountTextarea(element) {
+	updateTextarea(element);
+	element.addEventListener('input', onInput);
+	element.addEventListener('keydown', onKeyDown);
+	element.addEventListener('mousedown', onMouseDown);
+	element.addEventListener('mouseup', onMouseUp);
+}
+
 function getValue(element) {
-  return sym2raw(element.value);
+	return sym2raw(element.value);
 }

--- a/index.html
+++ b/index.html
@@ -70,6 +70,16 @@
           mountTextarea(this.refs.textarea);
         },
 
+        setValue: function (value) {
+          this.refs.textarea.focus();
+          this.props.onChange(setValue(this.refs.textarea, value));
+        },
+
+        insertAtCaret: function (value) {
+          this.refs.textarea.focus();
+          this.props.onChange(insertAtCaret(this.refs.textarea, value));
+        },
+
         handleChange: function () {
           this.props.onChange(getValue(this.refs.textarea));
         },
@@ -99,6 +109,14 @@
           this.setState({ value: newValue });
         },
 
+        handleResetButtonClick: function(e) {
+          this.refs.rawtextarea.setValue(initialText);
+        },
+
+        handleInsertButtonClick: function(e) {
+          this.refs.rawtextarea.insertAtCaret('{FOO}');
+        },
+
         render: function() {
           return (
             React.DOM.div(
@@ -106,7 +124,14 @@
               RawFontTextareaFactory({
                 defaultValue: this.props.initialValue,
                 onChange: this.handleChange,
+                ref: 'rawtextarea'
               }),
+              React.DOM.button({
+                onClick: this.handleResetButtonClick
+              }, 'Reset value'),
+              React.DOM.button({
+                onClick: this.handleInsertButtonClick
+              }, 'Insert "{FOO}" at caret'),
               React.DOM.p(null, 'State value'),
               React.DOM.p(
                 { className: 'state-value' },
@@ -123,12 +148,12 @@
           return (
             React.DOM.div(null,
               React.DOM.div(
-                { id: 'ltr' }, 
+                { id: 'ltr' },
                 React.DOM.p(null, 'Textarea (LTR)'),
                 MiniEditorFactory({ initialValue: initialText })
               ),
               React.DOM.div(
-                { id: 'rtl' }, 
+                { id: 'rtl' },
                 React.DOM.p(null, 'Textarea (RTL)'),
                 MiniEditorFactory({ initialValue: initialText })
               )

--- a/index.html
+++ b/index.html
@@ -67,12 +67,7 @@
         },
 
         componentDidMount: function() {
-          var textarea = this.refs.textarea;
-          updateTextarea(textarea);
-          textarea.addEventListener('input', onInput);
-          textarea.addEventListener('keydown', onKeyDown);
-          textarea.addEventListener('mousedown', onMouseDown);
-          textarea.addEventListener('mouseup', onMouseUp);
+          mountTextarea(this.refs.textarea);
         },
 
         handleChange: function () {


### PR DESCRIPTION
Please see individual commit messages for further details. This addresses all your recent comments (Mac shortcuts, ability to replace or insert text programmatically, handling clipboard).

I'm relying on you to test the [Mac shortcuts](https://support.apple.com/en-us/HT201236):

`Control-A` Move to the beginning of the line or paragraph.
`Control-E` Move to the end of a line or paragraph.
`Control-F` Move one character forward.
`Control-B` Move one character backward.
`Control-L` Center the cursor or selection in the visible area.
`Control-P` Move up one line.
`Control-N` Move down one line.
`Control-O` Insert a new line after the insertion point.
`Control-T` Swap the character behind the insertion point with the character in front of the insertion point.

(I suspect the `Control-T` one might produce some odd results, though I'm not sure what is its real value).
